### PR TITLE
Exclude more non-code from release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,15 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
-# Ignore all test and documentation with "export-ignore".
+# Ignore dot files, test and documentation with "export-ignore".
+/.editorconfig      export-ignore
 /.gitattributes     export-ignore
+/.github            export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
+/.styleci.yml       export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md    export-ignore
+/phpunit.xml.dist   export-ignore
 /test               export-ignore
 /docs               export-ignore


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/199095/78761926-efdeea00-798b-11ea-8caf-5f96491d6e97.png)


Initially i added more dotfiles:

```
/.gitignore         export-ignore
/.travis.yml        export-ignore
/phpunit.xml.dist   export-ignore
/.scrutinizer.yml   export-ignore
/.styleci.yml   export-ignore
/.editorconfig   export-ignore
/.phpstorm.meta.php   export-ignore
```

but seems this can be simplified with excluding all dotfiles.