### PR TITLE
fix: parse json5 codes always thorw JsonException 

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit bootstrap="test/bootstrap.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"

--- a/src/Json5Decoder.php
+++ b/src/Json5Decoder.php
@@ -73,9 +73,10 @@ final class Json5Decoder
         // Try parsing with json_decode first, since that's much faster
         // We only attempt this on PHP 7+ because 5.x doesn't parse some edge cases correctly
         if (PHP_VERSION_ID >= 70000) {
-            $result = \json_decode($source, $associative, $depth, $options);
-            if (\json_last_error() === \JSON_ERROR_NONE) {
-                return $result;
+            try {
+                $result = \json_decode($source, $associative, $depth, $options | \JSON_THROW_ON_ERROR);
+            } catch (\Throwable $e) {
+                // ignore exception, continue parse.
             }
         }
 
@@ -135,7 +136,7 @@ final class Json5Decoder
         }
 
         $this->at++;
-        
+
         return $this->currentByte = $this->getByte($this->at);
     }
 

--- a/src/Json5Decoder.php
+++ b/src/Json5Decoder.php
@@ -74,7 +74,10 @@ final class Json5Decoder
         // We only attempt this on PHP 7+ because 5.x doesn't parse some edge cases correctly
         if (PHP_VERSION_ID >= 70000) {
             try {
-                return \json_decode($source, $associative, $depth, $options | \JSON_THROW_ON_ERROR);
+                $result = \json_decode($source, $associative, $depth, $options);
+                if (\json_last_error() === \JSON_ERROR_NONE) {
+                    return $result;
+                }
             } catch (\Throwable $e) {
                 // ignore exception, continue parsing as JSON5
             }

--- a/src/Json5Decoder.php
+++ b/src/Json5Decoder.php
@@ -74,9 +74,9 @@ final class Json5Decoder
         // We only attempt this on PHP 7+ because 5.x doesn't parse some edge cases correctly
         if (PHP_VERSION_ID >= 70000) {
             try {
-                $result = \json_decode($source, $associative, $depth, $options | \JSON_THROW_ON_ERROR);
+                return \json_decode($source, $associative, $depth, $options | \JSON_THROW_ON_ERROR);
             } catch (\Throwable $e) {
-                // ignore exception, continue parse.
+                // ignore exception, continue parsing as JSON5
             }
         }
 

--- a/test/Functional/ParseTest.php
+++ b/test/Functional/ParseTest.php
@@ -202,6 +202,22 @@ class ParseTest extends TestCase
         $this->assertEquals(Json5Decoder::decode($json, true), json5_decode($json, true));
     }
 
+    /**
+     * BUG: parse json5 codes always thorw JsonException on set JSON_THROW_ON_ERROR
+     * more see https://github.com/colinodell/json5/issues/15
+     *
+     * @return void
+     */
+    public function testIssues15_parseException()
+    {
+        $ret = Json5Decoder::decode('{
+            "name": "tom", // has comments
+        }');
+
+        $this->assertNotEmpty($ret);
+        $this->assertEquals(['name' => 'tom'], $ret);
+    }
+
     private function getErrorSpec($file)
     {
         $errorSpec = str_replace('.txt', '.errorSpec', $file);

--- a/test/Functional/ParseTest.php
+++ b/test/Functional/ParseTest.php
@@ -203,19 +203,15 @@ class ParseTest extends TestCase
     }
 
     /**
-     * BUG: parse json5 codes always thorw JsonException on set JSON_THROW_ON_ERROR
-     * more see https://github.com/colinodell/json5/issues/15
+     * Regression: Parsing JSON5 always throws JsonException when JSON_THROW_ON_ERROR is set by the caller
      *
-     * @return void
+     * @see https://github.com/colinodell/json5/issues/15
      */
-    public function testIssues15_parseException()
+    public function testExceptionShouldNotBeThrownOnValidJSON5()
     {
-        $ret = Json5Decoder::decode('{
-            "name": "tom", // has comments
-        }');
+        $ret = Json5Decoder::decode('"foo" // simple string with a comment', false, 512, JSON_THROW_ON_ERROR);
 
-        $this->assertNotEmpty($ret);
-        $this->assertEquals(['name' => 'tom'], $ret);
+        $this->assertEquals('foo', $ret);
     }
 
     private function getErrorSpec($file)

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/global.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix: parse json5 codes always thorw JsonException on set JSON_THROW_ON_ERROR

## Motivation and context

Why is this change required? What problem does it solve?

- close #15 

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Sample JSON (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change adds a new code file, I have added the copyright header to it.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
