### PR TITLE
Add @throws tags to the public API

### DIFF
--- a/src/Json5Decoder.php
+++ b/src/Json5Decoder.php
@@ -66,6 +66,8 @@ final class Json5Decoder
      * @param int    $depth       User specified recursion depth.
      * @param int    $options     Bitmask of JSON decode options.
      *
+     * @throws SyntaxError if the JSON encoded string could not be parsed.
+     *
      * @return mixed
      */
     public static function decode($source, $associative = false, $depth = 512, $options = 0)

--- a/src/global.php
+++ b/src/global.php
@@ -13,6 +13,8 @@ if (!function_exists('json5_decode')) {
      * @param int    $depth       User specified recursion depth.
      * @param int    $options     Bitmask of JSON decode options.
      *
+     * @throws \ColinODell\Json5\SyntaxError if the JSON encoded string could not be parsed.
+     *
      * @return mixed
      */
     function json5_decode($source, $associative = false, $depth = 512, $options = 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

👋, thanks for this package! This is a very minor change that adds `@throws` [tags](https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/throws.html) to the docblocks of the `json5_decode` function and `Json5Decoder::decode` method—as some IDE's (namely, PhpStorm) don't seem to be able to infer that both of these calls can throw, which leads to inspections about unnecessarily catching `SyntaxError`'s.

## How has this been tested?

No new tests needed, but `composer check-style` reports no problems.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.