### PR TITLE
remove $ so gitclip works

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ multi-line string',
 Via Composer
 
 ``` bash
-$ composer require colinodell/json5
+composer require colinodell/json5
 ```
 
 ## Usage
@@ -114,7 +114,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$ composer test
+composer test
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and context

The little cut icon on github includes the $, so you can't paste.